### PR TITLE
Bug fix preventing keyboard from closing after clear button press

### DIFF
--- a/src/components/searchbar/searchbar.ts
+++ b/src/components/searchbar/searchbar.ts
@@ -342,7 +342,11 @@ export class Searchbar extends BaseInput<string> {
         this.ionInput.emit(ev);
       }
     }, 16 * 4);
-    this._shouldBlur = false;
+    
+    //Go back to input focus if clear has been pressed with input already focused
+    if(this._isFocus && ev.type === "mousedown"){
+      this._shouldBlur = false;
+    }
   }
 
   /**


### PR DESCRIPTION
(click) and (mousedown) events are both fired when pressing clear(X) button, this causes a range of issues including not allowing the keyboard to close after clear has been pressed. This is due to the fact that _shouldBlur is left in the false state after clear rather then being reset to true. Issue is as follows.
1.Clear is pressed
2.clearInput from (mousdown) fires _shouldBlur = false
3.inputBlurred fires from deselecting input _shouldBlur = true
4.clearInput from (click) firest _shouldBlur = false.

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes**: #
